### PR TITLE
.github/workflows: add atlas ci workflow

### DIFF
--- a/.github/workflows/ci-atlas.yaml
+++ b/.github/workflows/ci-atlas.yaml
@@ -1,0 +1,35 @@
+name: Atlas
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    paths:
+      - 'sqlite_dir/*'
+# Permissions to write comments on the pull request.
+permissions:
+  contents: read
+  pull-requests: write
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - uses: ariga/atlas-action@master
+        with:
+          dir: 'sqlite_dir'
+          dev-url: 'sqlite://dev?mode=memory'
+          cloud-token: ${{ secrets.ATLAS_CLOUD_TOKEN_YJEK06 }}
+  sync:
+    needs: lint
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ariga/atlas-sync-action@v0
+        with:
+          dir: 'sqlite_dir'
+          dev-url: 'sqlite://dev?mode=memory'
+          cloud-token: ${{ secrets.ATLAS_CLOUD_TOKEN_YJEK06 }}


### PR DESCRIPTION
PR created by the `gh atlas init-action` command.
 for more information visit https://github.com/ariga/gh-atlas.