### PR TITLE
.github/workflows: add atlas ci workflow

### DIFF
--- a/.github/workflows/ci-atlas.yaml
+++ b/.github/workflows/ci-atlas.yaml
@@ -1,0 +1,40 @@
+name: Atlas
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - .github/workflows/ci-atlas.yaml
+      - './/*'
+  pull_request:
+    paths:
+      - './/*'
+# Permissions to write comments on the pull request.
+permissions:
+  contents: read
+  pull-requests: write
+jobs:
+  atlas:
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_TOKEN: ${{ github.token }}
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - uses: ariga/setup-atlas@v0
+        with:
+          cloud-token: ${{ secrets.ATLAS_CLOUD_TOKEN_WNKONZ }}
+      - uses: ariga/atlas-action/migrate/lint@v1
+        with:
+          dir: 'file://./'
+          dir-name: 'spanner'
+          config: 'file://atlas.hcl'
+          env: 'dev'
+      - uses: ariga/atlas-action/migrate/push@v1
+        if: github.ref == 'refs/heads/main'
+        with:
+          dir: 'file://./'
+          dir-name: 'spanner'
+          config: 'file://atlas.hcl'
+          env: 'dev'


### PR DESCRIPTION
PR created by the `gh atlas init-action` command.
 for more information visit https://github.com/ariga/gh-atlas.